### PR TITLE
Update which mail to send from for nominations and notifications

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -111,7 +111,7 @@ class User extends Authenticatable {
         $positions = Position::dataForIds($positionIds);
 
         $to = $this->kth_username . "@kth.se";
-        $from = "valberedning@d.kth.se";
+        $from = "valberedning@datasektionen.se";
         $subject = "Påminnelse: Svara på dina nomineringar";
         $html = view('emails.remind')
             ->with('person', $this)
@@ -304,7 +304,7 @@ class User extends Authenticatable {
 
         $to = $this->kth_username . "@kth.se";
         $positions = Position::dataForIds($positionIds);
-        $from = "valberedning@d.kth.se";
+        $from = "valberedning@datasektionen.se";
         $subject = "Du har nya nomineringar";
         $html = view('emails.notify-nomination')
             ->with('person', $this)
@@ -381,7 +381,7 @@ class User extends Authenticatable {
 
         $to = $this->kth_username . "@kth.se";
         $positions = Position::dataForIds($positionIds);
-        $from = "valberedning@d.kth.se";
+        $from = "valberedning@datasektionen.se";
         $subject = "Du har nya nomineringar";
         $html = view('emails.notify-nomination')
             ->with('person', $this)


### PR DESCRIPTION
Valberedningen currently receives error messages when people are nominated to stuff, and nominees don't get emails. This is bad for the valberedare who get spammed, and for the chapter, since people don't get notified when they are nominated, making it less likely that they accept.  

[Spam allows sending emails from all `@datasektionen.se` addresses](https://github.com/datasektionen/spam/blob/master/api.js#L47), so this change should work. It is also used successfully in [pandora](https://github.com/datasektionen/pandora/blob/master/app/Helpers/EmailClient.php#L37) already.

I considered changing all the places where `valberedningen@d.kth.se` is mentioned in plain-text to `valberedningen@datasektionen.se`, but since `@d.kth.se` mails are forwarded to `@datasektionen.se` currently, and not all valberedare has migrated to using workspace, it thought it best to wait.

Not tested locally, since this system has been really annoying to get running locally, and I don't have a spam-key. However, due to the above reasons, I am fairly confident that this change will work.