### PR TITLE
Change how names are displayed

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -90,7 +90,7 @@
 									Tackat nej:
 								@endif
 
-								<a href="/person/{{ $nominee->kth_username }}">{{ $nominee->name }}</a>
+								<a href="/person/{{ $nominee->kth_username }}">{{ $nominee->name }} ({{ $nominee->kth_username }})</a>
 
 								@if (Auth::check() && session('admin') == Auth::user()->id)
 									<a href="/admin/elections/edit-nomination/{{ $nominee->uuid }}">Ändra</a>


### PR DESCRIPTION
Before this names were displayed straight from how they were stored in the database. Now the page displays the name from the database followed by the kth username in parentheses. @TerraDOOM has already helped me remove the kth usernames from the names in the database to avoid duplication.