### PR TITLE
Dont use https when not using https

### DIFF
--- a/resources/views/admin/blacklist/index.blade.php
+++ b/resources/views/admin/blacklist/index.blade.php
@@ -7,7 +7,7 @@
 @endsection
 
 @section('admin-content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <p>Blacklisten innehåller KTH-användarnamn som inte kan nomineras till poster.</p>
 <table>
 	<tr>

--- a/resources/views/admin/blacklist/new.blade.php
+++ b/resources/views/admin/blacklist/new.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Skapa ny person')
 
 @section('content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <div class="form-entry">
         <span class="description">

--- a/resources/views/admin/elections/edit-nomination.blade.php
+++ b/resources/views/admin/elections/edit-nomination.blade.php
@@ -6,7 +6,7 @@
 <p>Du ändrar att <b>{{ $user->name }}</b> är nominerad till <b>{{ $positions[$positionId]->title }}</b> i valet {{ $election->name }}. Just nu är statusen "{{ $nomination->status == 'accepted' ? 'Accepterad' : ($nomination->status == 'declined' ? 'Tackat nej' : 'Inte svarat') }}".</p>
 
 <p><a href="/admin/elections/remove-nomination/{{ $uuid }}">Du kan också ta bort nomineringen genom att klicka här.</a></p>
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <div class="form-entry">
         <span class="description">

--- a/resources/views/admin/elections/edit-positions.blade.php
+++ b/resources/views/admin/elections/edit-positions.blade.php
@@ -29,7 +29,7 @@ $(document).ready(function () {
 @endsection
 
 @section('content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <table>
         <tr style='background:#eee'>

--- a/resources/views/admin/elections/edit.blade kopia.php
+++ b/resources/views/admin/elections/edit.blade kopia.php
@@ -29,7 +29,7 @@ $(document).ready(function () {
 @endsection
 
 @section('content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <table>
         <tr style='background:#eee'>

--- a/resources/views/admin/elections/edit.blade.php
+++ b/resources/views/admin/elections/edit.blade.php
@@ -7,7 +7,7 @@
 @endsection
 
 @section('content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <div class="form-entry">
         <span class="description">

--- a/resources/views/admin/elections/new.blade.php
+++ b/resources/views/admin/elections/new.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Skapa nytt val')
 
 @section('content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <div class="form-entry">
         <span class="description">

--- a/resources/views/admin/persons/edit.blade.php
+++ b/resources/views/admin/persons/edit.blade.php
@@ -7,7 +7,7 @@
 @endsection
 
 @section('content')
-{!! Form::model($person, ['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::model($person, ['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <div class="form-entry">
         <span class="description">

--- a/resources/views/admin/persons/new.blade.php
+++ b/resources/views/admin/persons/new.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Skapa ny person')
 
 @section('content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <div class="form-entry">
         <span class="description">

--- a/resources/views/admin/reminders/index.blade.php
+++ b/resources/views/admin/reminders/index.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Påminnelsemejl')
 
 @section('admin-content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <p>Personer som inte har svarat på minst en aktuell nominering visas i tabellen nedan. Du kan bara påminna personer som du inte påmint inom de 24 senaste timmarna.</p>
 <table>
 	<tr>

--- a/resources/views/admin/whitelist/index.blade.php
+++ b/resources/views/admin/whitelist/index.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Användare som inte får e-post')
 
 @section('admin-content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <p>Det här är en lista över personer som blivit tillagda men inte fått något mejl. Om du kan bekräfta att dessa personer är medlemmar i Datasektionen (eller kan bli), så gör det. Om personerna inte är seriösa kandidater, bekräfta inte. Du kan också lägga till dem i blacklisten direkt.</p>
 <table>
 	<tr>

--- a/resources/views/nominate.blade.php
+++ b/resources/views/nominate.blade.php
@@ -72,7 +72,7 @@ $(document).ready(function () {
     <p>Det finns inga öppna val att nominera i.</p>
 @else
 
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <div class="form-entry">
         <span class="description">

--- a/resources/views/user/settings.blade.php
+++ b/resources/views/user/settings.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Dina inställningar')
 
 @section('content')
-{!! Form::open(['url' => URL::to(Request::path(), [], true)]) !!}
+{!! Form::open(['url' => URL::to(Request::path(), [], Request::secure())]) !!}
 <div class="form">
     <div class="form-entry">
         <span class="description">


### PR DESCRIPTION
All forms currently redirect to `https` which makes local development harder.

This change checks if the current page is using http or https and uses the same as action on the form.