### PR TITLE
Make making new users consistent

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -68,7 +68,7 @@ class AuthController extends BaseController {
 		if ($user === null) {
 			// Create new user in our systems if did not exist
 			$user = new User;
-			$user->name = $body->first_name . " " . $body->last_name;
+			$user->name = $body->displayName;
 			$user->kth_username = strtolower($body->user);
 			$user->kth_user_id = strtolower($body->ugkthid);
 			$user->year = "";

--- a/app/Http/Controllers/NominationController.php
+++ b/app/Http/Controllers/NominationController.php
@@ -81,7 +81,7 @@ class NominationController extends BaseController {
 				return redirect('/')->with('error', $kth_username . ' kunde inte hittas.');
 			}
 			$user = new User;
-			$user->name = $body->cn;
+			$user->name = $body->displayName;
 			$user->kth_user_id = strtolower($body->ugKthid);
 			$user->kth_username = strtolower($body->uid);
 			$user->year = $request->input('year', $body->year);

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -90,7 +90,7 @@
 									Tackat nej:
 								@endif
 
-								<a href="/person/{{ $nominee->kth_username }}">{{ $nominee->name }}</a>
+								<a href="/person/{{ $nominee->kth_username }}">{{ $nominee->name }} ({{ $nominee->kth_username }})</a>
 
 								@if (Auth::check() && session('admin') == Auth::user()->id)
 									<a href="/admin/elections/edit-nomination/{{ $nominee->uuid }}">Ändra</a>


### PR DESCRIPTION
Previously how names were formatted depended on if they were introduced to the system by being nominated or logging in. Now both take the display name from Hoodis. PersonContoller also adds people a different way but I don't understand it enough to touch it.