### PR TITLE
Fix running migrations in docker

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 su www -c 'php artisan config:cache'
-su www -c 'php artisan migrate'
+su www -c 'php artisan migrate --force'
 
 su www -c 'php-fpm7 -F' &
 nginx -g 'daemon off;' &


### PR DESCRIPTION
Apparently the migrations don't want to run in production unless you specify `--force`.