### PR TITLE
Update d.kth.se and https URLs

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -45,7 +45,7 @@ class Controller extends BaseController {
 		}
 
 		try {
-			$roles = @file_get_contents('http://dfunkt.datasektionen.se/api/user/kthid/' . $user->kth_username);
+			$roles = @file_get_contents('https://dfunkt.datasektionen.se/api/user/kthid/' . $user->kth_username);
 			if ($roles === FALSE) {
 				$mandates = collect([]);
 			} else {

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -63,7 +63,7 @@ class Position {
      * @return json decoded roles list
      */
     public static function active($columns = array()) {
-        $rolesString = file_get_contents('http://dfunkt.datasektionen.se/api/active-roles');
+        $rolesString = file_get_contents('https://dfunkt.datasektionen.se/api/active-roles');
         $roles = json_decode($rolesString);
         usort($roles, function ($a, $b) {
             return strcmp($a->title, $b->title);
@@ -78,7 +78,7 @@ class Position {
      * @return json decoded response from api
      */
     public static function find($identifier) {
-        $ans = file_get_contents("http://dfunkt.datasektionen.se/api/role/" . $identifier);
+        $ans = file_get_contents("https://dfunkt.datasektionen.se/api/role/" . $identifier);
         return json_decode($ans);
     }
 
@@ -89,7 +89,7 @@ class Position {
      * @return array  the roles
      */
     public static function allKey($columns = array()) {
-        $rolesString = file_get_contents('http://dfunkt.datasektionen.se/api/active-roles');
+        $rolesString = file_get_contents('https://dfunkt.datasektionen.se/api/active-roles');
         $roles = json_decode($rolesString);
 
         $res = [];
@@ -107,7 +107,7 @@ class Position {
      */
     public static function dataForIds($positions) {
         $ans = [];
-        $rolesString = file_get_contents('http://dfunkt.datasektionen.se/api/roles');
+        $rolesString = file_get_contents('https://dfunkt.datasektionen.se/api/roles');
         $roles = json_decode($rolesString);
 
         foreach ($positions as $position) {

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ DB_USERNAME=
 DB_PASSWORD=
 
 LOGIN_API_KEY=
-LOGIN_API_URL=https://login.datasektionen.se
-LOGIN_FRONTEND_URL=https://login.datasektionen.se
+LOGIN_API_URL=https://sso.datasektionen.se/legacyapi
+LOGIN_FRONTEND_URL=https://sso.datasektionen.se/legacyapi
 PLS_API_URL=https://pls.datasektionen.se/api
 ZFINGER_API_URL=https://zfinger.datasektionen.se
 SPAM_API_KEY=

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 PHP (</3) Laravel application that handles elections. An election is an event with starting and ending date (also containing dates for nomination and acceptance stops). An election has at least one position open for election. 
 
 ## API
-There is an API for Skywhale. The API is located at ```/api``` (http://val.datasektionen.se/api).
+There is an API for Skywhale. The API is located at ```/api``` (https://val.datasektionen.se/api).
 
 ### API endpoints
 The following endpoints are based on the above URL.
@@ -27,7 +27,7 @@ DB_PASSWORD=
 LOGIN_API_KEY=
 LOGIN_API_URL=https://login.datasektionen.se
 LOGIN_FRONTEND_URL=https://login.datasektionen.se
-PLS_API_URL=http://pls.datasektionen.se/api
+PLS_API_URL=https://pls.datasektionen.se/api
 ZFINGER_API_URL=https://zfinger.datasektionen.se
 SPAM_API_KEY=
 SPAM_API_URL=https://spam.datasektionen.se/api/sendmail

--- a/resources/views/emails/notify-nomination.blade.php
+++ b/resources/views/emails/notify-nomination.blade.php
@@ -13,7 +13,7 @@ För att kunna tacka ja till en nominering och sedan bli vald måste du vara sek
 
 [Du svarar på din nominering genom att trycka på denna länk.]({{ url('/nomination/answer') }}) Vi ser gärna att du svarar så fort du har bestämt dig för att underlätta i vårt arbete, dock är sista dagen att acceptera nomineringen {{ date("j/n Y",strtotime($election->acceptance_stop)-(86399/2)) }}.
 
-På [valsidan]({{ url('/') }}) kan du se vilka andra som är nominerade. Se även [funktionärssidan](http://dfunkt.datasektionen.se) för mer utförlig information om posten. Det går även bra att fråga medlemmarna i Valberedningen eller skicka eventuella frågor till [valberedning@d.kth.se](mailto:valberedning@d.kth.se).
+På [valsidan]({{ url('/') }}) kan du se vilka andra som är nominerade. Se även [funktionärssidan](https://dfunkt.datasektionen.se) för mer utförlig information om posten. Det går även bra att fråga medlemmarna i Valberedningen eller skicka eventuella frågor till [valberedning@datasektionen.se](mailto:valberedning@datasektionen.se).
 @endsection
 
 @section('ps')

--- a/resources/views/emails/notify-nomination.blade.php
+++ b/resources/views/emails/notify-nomination.blade.php
@@ -9,7 +9,7 @@ Den {{ date("j/n Y", strtotime($election->closes)) }} äger {{ $election->name }
 * {{ $position->title }}
 @endforeach
 
-För att kunna tacka ja till en nominering och sedan bli vald måste du vara sektionsmedlem i Konglig Datasektionen. Om du inte är det kan du enkelt bli medlem genom att betala ett medlemskap till kåren på [ths.kth.se](http://ths.kth.se).
+För att kunna tacka ja till en nominering och sedan bli vald måste du vara sektionsmedlem i Konglig Datasektionen. Om du inte är det kan du enkelt bli medlem genom att betala ett medlemskap till kåren på [thskth.se](https://thskth.se).
 
 [Du svarar på din nominering genom att trycka på denna länk.]({{ url('/nomination/answer') }}) Vi ser gärna att du svarar så fort du har bestämt dig för att underlätta i vårt arbete, dock är sista dagen att acceptera nomineringen {{ date("j/n Y",strtotime($election->acceptance_stop)-(86399/2)) }}.
 

--- a/resources/views/emails/remind.blade.php
+++ b/resources/views/emails/remind.blade.php
@@ -13,5 +13,5 @@ Vi skulle nu vilja att du [besöker valsidan]({{ url('/nomination/answer') }}) o
 
 För att kunna tacka ja till en nominering och sedan bli vald måste du vara sektionsmedlem i Konglig Datasektionen. Om du inte är det kan du enkelt bli medlem genom att betala ett medlemskap till kåren på [ths.kth.se](//ths.kth.se).
 
-På [valsidan]({{ url('/') }}) kan du se vilka andra som är nominerade. Se även [funktionärssidan](http://dfunkt.datasektionen.se) för mer utförlig information om posten. Det går även bra att fråga medlemmarna i Valberedningen eller skicka eventuella frågor till [valberedning@d.kth.se](mailto:valberedning@d.kth.se).
+På [valsidan]({{ url('/') }}) kan du se vilka andra som är nominerade. Se även [funktionärssidan](https://dfunkt.datasektionen.se) för mer utförlig information om posten. Det går även bra att fråga medlemmarna i Valberedningen eller skicka eventuella frågor till [valberedning@datasektionen.se](mailto:valberedning@datasektionen.se).
 @endsection

--- a/resources/views/emails/remind.blade.php
+++ b/resources/views/emails/remind.blade.php
@@ -11,7 +11,7 @@ Den {{ date("j/n Y", strtotime($election->closes)) }} äger {{ $election->name }
 
 Vi skulle nu vilja att du [besöker valsidan]({{ url('/nomination/answer') }}) och svarar på dina nomineringar. Länken är [{{ url('/nomination/answer') }}]({{ url('/nomination/answer') }}) om din e-postklient inte klarar av att visa länkar. Sista dagen att acceptera dina nomineringar är {{ date("j/n Y",strtotime($election->acceptance_stop)-(86399/2)) }}, om inget speciellt gäller för de poster du blivit nominerad till.
 
-För att kunna tacka ja till en nominering och sedan bli vald måste du vara sektionsmedlem i Konglig Datasektionen. Om du inte är det kan du enkelt bli medlem genom att betala ett medlemskap till kåren på [ths.kth.se](//ths.kth.se).
+För att kunna tacka ja till en nominering och sedan bli vald måste du vara sektionsmedlem i Konglig Datasektionen. Om du inte är det kan du enkelt bli medlem genom att betala ett medlemskap till kåren på [thskth.se](https://thskth.se).
 
 På [valsidan]({{ url('/') }}) kan du se vilka andra som är nominerade. Se även [funktionärssidan](https://dfunkt.datasektionen.se) för mer utförlig information om posten. Det går även bra att fråga medlemmarna i Valberedningen eller skicka eventuella frågor till [valberedning@datasektionen.se](mailto:valberedning@datasektionen.se).
 @endsection

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -68,7 +68,7 @@
             <div class="clear"></div>
         </div>
         <footer>
-            <a href="http://github.com/datasektionen/skywhale" class="footer">&#10084;</a>
+            <a href="https://github.com/datasektionen/skywhale" class="footer">&#10084;</a>
         </footer>
 
     </div>

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -68,7 +68,7 @@
             <div class="clear"></div>
         </div>
         <footer>
-            <a href="http://github.com/datasektionen/skywhale" class="footer">&#10084;</a>
+            <a href="https://github.com/datasektionen/skywhale" class="footer">&#10084;</a>
         </footer>
 
     </div>

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -68,7 +68,7 @@
             <div class="clear"></div>
         </div>
         <footer>
-            <a href="http://github.com/datasektionen/skywhale" class="footer">&#10084;</a>
+            <a href="https://github.com/datasektionen/skywhale" class="footer">&#10084;</a>
         </footer>
 
     </div>


### PR DESCRIPTION
Some emails still notified users to contact `valberedning@d.kth.se` so this updates those to `valberedning@datasektionen.se`.

Also a lot of URLs were http so this updates all of the ones we care about to https.