### PR TITLE
fix: missing email on nomination

### DIFF
--- a/app/Http/Controllers/NominationController.php
+++ b/app/Http/Controllers/NominationController.php
@@ -82,6 +82,7 @@ class NominationController extends BaseController {
 			$user = new User;
 			$user->name = $body->firstName . " " . $body->familyName;
 			$user->kth_username = $kth_username;
+            $user->email = $body->email;
 			$user->year = $body->yearTag;
 			$user->save();
 		}


### PR DESCRIPTION
Fixes issue when nominating people without a user account

Fixes #79 